### PR TITLE
v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.1.0
+
+- Added a `deploy:build_assets` step into the default deploy task to build theme assets on local.
+This allows for easier overwriting this task (eg to build custom plugin assets) and fixes running duplicates on some configurations.
+
 ## v3.0.0
 
 - Did a large refactor of paths (release_path, current_path, document_root)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "gaambo/deployer-wordpress",
   "description": "Deployer tasks for deploying WordPress Sites",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "type": "library",
   "license": "MIT",
   "homepage": "https://github.com/gaambo/deployer-wordpress",

--- a/recipes/advanced.php
+++ b/recipes/advanced.php
@@ -17,6 +17,7 @@ add('recipes', ['simple-wp']);
 
 task('deploy', [
     'deploy:prepare',
+    'deploy:build_assets',
     'deploy:update_code',
     'deploy:symlink', // Add additional symlink task
     'deploy:publish'

--- a/recipes/simple.php
+++ b/recipes/simple.php
@@ -38,6 +38,7 @@ set('shared_dirs', []);
 
 task('deploy', [
     'deploy:prepare',
+    'deploy:build_assets',
     'deploy:update_code',
     'deploy:publish'
 ])->desc('Deploy WordPress Site');


### PR DESCRIPTION
- Added a `deploy:build_assets` step into the default deploy task to build theme assets on local.
This allows for easier overwriting this task (eg to build custom plugin assets) and fixes running duplicates on some configurations.