### PR TITLE
#15 Deployer v8 Support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,5 +6,6 @@
 /phpcs.xml export-ignore
 /phpstan.neon export-ignore
 /phpunit.xml export-ignore
+/phpstan/ export-ignore
 /stubs/ export-ignore
 /tests/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,5 @@
 /phpcs.xml export-ignore
 /phpstan.neon export-ignore
 /phpunit.xml export-ignore
-/tests/ export-ignore 
+/stubs/ export-ignore
+/tests/ export-ignore

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -52,9 +52,6 @@ jobs:
       - name: Validate composer.json
         run: composer validate --strict
 
-      - name: Audit Composer packages
-        run: composer audit --locked
-
       - name: Set Deployer version constraint
         env:
           DEPLOYER_VERSION: ${{ matrix.deployer }}
@@ -67,6 +64,9 @@ jobs:
         with:
           dependency-versions: highest
           composer-options: '--prefer-dist --no-progress'
+
+      - name: Audit Composer packages
+        run: composer audit
 
       - name: Run PHP syntax linting
         run: composer run-script lint

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   code-quality:
-    name: Run Code Quality Checks
+    name: Run Code Quality Checks (PHP ${{ matrix.php }}, Deployer ${{ matrix.deployer }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -23,7 +23,16 @@ jobs:
       checks: write # needed for cs2pr to post inline annotations
     strategy:
       matrix:
-        php: [ '8.2', '8.3', '8.4', '8.5' ]
+        include:
+          - { php: '8.2', deployer: '7.3' }
+          - { php: '8.2', deployer: '7.4' }
+          - { php: '8.2', deployer: '7.5' }
+          - { php: '8.3', deployer: '7.3' }
+          - { php: '8.3', deployer: '7.4' }
+          - { php: '8.3', deployer: '7.5' }
+          - { php: '8.3', deployer: '8.0' }
+          - { php: '8.4', deployer: '8.0' }
+          - { php: '8.5', deployer: '8.0' }
       fail-fast: false
 
     steps:
@@ -46,10 +55,17 @@ jobs:
       - name: Audit Composer packages
         run: composer audit --locked
 
-      # Install dependencies with caching
+      - name: Set Deployer version constraint
+        env:
+          DEPLOYER_VERSION: ${{ matrix.deployer }}
+        run: composer require --no-update deployer/deployer:"${DEPLOYER_VERSION}.*"
+
+      # Install dependencies with caching — uses `composer update` (highest) so the pinned
+      # deployer constraint above is actually resolved.
       - name: Install Composer dependencies
         uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
         with:
+          dependency-versions: highest
           composer-options: '--prefer-dist --no-progress'
 
       - name: Run PHP syntax linting

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,9 @@ jobs:
       matrix:
         php: [ '8.2', '8.3', '8.4', '8.5' ]
         deployer: [ '7.3', '7.4', '7.5', '8.0' ]
+        exclude:
+          - php: '8.2'
+            deployer: '8.0'
       fail-fast: false
     name: Tests for Deployer ${{ matrix.deployer }} on PHP ${{ matrix.php }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,18 +39,21 @@ jobs:
           php-version: ${{ matrix.php }}
           tools: composer:v2
 
-      # Install dependencies with caching
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
-        with:
-          composer-options: '--prefer-dist --no-progress'
-
-      # Install specific Deployer version
-      - name: Install Deployer version
-        # Install latest patch of the specified version.
+      # Pin the Deployer version constraint before installing, so the install
+      # step resolves the right version (and fails fast on invalid combos like
+      # PHP 8.2 + Deployer 8 which requires PHP ^8.3).
+      - name: Set Deployer version constraint
         env:
           DEPLOYER_VERSION: ${{ matrix.deployer }}
         run: composer require --no-update deployer/deployer:"${DEPLOYER_VERSION}.*"
+
+      # Install dependencies with caching — uses `composer update` (highest)
+      # so the pinned deployer constraint above is actually resolved.
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
+        with:
+          dependency-versions: highest
+          composer-options: '--prefer-dist --no-progress'
 
       # Run PHPStan so we check compatibility with the specified Deployer version.
       - name: Run PHPStan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,7 @@ jobs:
     strategy:
       matrix:
         php: [ '8.2', '8.3', '8.4', '8.5' ]
-        # TODO: Add 8.0 when released.
-        deployer: [ '7.3', '7.4', '7.5' ]
+        deployer: [ '7.3', '7.4', '7.5', '8.0' ]
       fail-fast: false
     name: Tests for Deployer ${{ matrix.deployer }} on PHP ${{ matrix.php }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,11 +18,16 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        php: [ '8.2', '8.3', '8.4', '8.5' ]
-        deployer: [ '7.3', '7.4', '7.5', '8.0' ]
-        exclude:
-          - php: '8.2'
-            deployer: '8.0'
+        include:
+          - { php: '8.2', deployer: '7.3' }
+          - { php: '8.2', deployer: '7.4' }
+          - { php: '8.2', deployer: '7.5' }
+          - { php: '8.3', deployer: '7.3' }
+          - { php: '8.3', deployer: '7.4' }
+          - { php: '8.3', deployer: '7.5' }
+          - { php: '8.3', deployer: '8.0' }
+          - { php: '8.4', deployer: '8.0' }
+          - { php: '8.5', deployer: '8.0' }
       fail-fast: false
     name: Tests for Deployer ${{ matrix.deployer }} on PHP ${{ matrix.php }}
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,20 @@ follows PSR-2 and Deployer best practices.
 
 The library includes a comprehensive test suite with unit, integration, and functional tests.
 
-- Run `composer phpunit` to execute all tests.
+- Run `composer precommit` before submitting a PR — it runs lint, code style, PHPStan, and all tests.
 - Functional tests use a mocked environment to verify rsync commands and file operations without real remote
   connections.
+
+The library supports both Deployer v7 and v8. Test against both before submitting:
+
+```bash
+# Switch to Deployer v7
+composer require --no-update deployer/deployer:"7.5.*"
+composer update deployer/deployer --with-dependencies
+composer precommit
+
+# Switch back to v8
+composer require --no-update deployer/deployer:"^7.3 || ^8.0"
+composer update deployer/deployer --with-dependencies
+composer precommit
+```

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ The library includes a comprehensive test suite with unit, integration, and func
 - Functional tests use a mocked environment to verify rsync commands and file operations without real remote
   connections.
 
-The library supports both Deployer v7 and v8. Test against both before submitting:
+The library supports both Deployer v7 and v8. Test against both before submitting (note: Deployer v7 requires PHP 8.2 or 8.3 — it is incompatible with PHP 8.4+):
 
 ```bash
 # Switch to Deployer v7

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
   "autoload-dev": {
     "psr-4": {
       "Gaambo\\DeployerWordpress\\Tests\\": "tests/",
+      "Gaambo\\DeployerWordpress\\PHPStan\\": "phpstan/",
       "Deployer\\": "vendor/deployer/deployer/src/"
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,13 @@
     "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^10.5",
     "squizlabs/php_codesniffer": "^3.11 || ^4.0",
-    "symfony/console": "^6.4",
-    "symfony/process": "^6.4"
+    "symfony/console": "^6.4 || ^7.4.0 || ^8.0.0",
+    "symfony/process": "^6.4 || ^7.4.0 || ^8.0.0"
   },
   "require": {
     "php": "^8.2",
-    "deployer/deployer": "^7.3"
+    "composer-runtime-api": "^2.0",
+    "deployer/deployer": "^7.3 || ^8.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,37 +4,48 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a15a640fb68fe4e27e7eb64ffa67a78",
+    "content-hash": "ebdcbae99c91467f362967558ee2aad1",
     "packages": [
         {
             "name": "deployer/deployer",
-            "version": "v7.5.12",
+            "version": "v8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/deployphp/deployer.git",
-                "reference": "efc71dac9ccc86b3f9946e75d50cb106b775aae2"
+                "reference": "d091b92a3ead8c5b9358f9e6c65a13b8fbd7f183"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/deployphp/deployer/zipball/efc71dac9ccc86b3f9946e75d50cb106b775aae2",
-                "reference": "efc71dac9ccc86b3f9946e75d50cb106b775aae2",
+                "url": "https://api.github.com/repos/deployphp/deployer/zipball/d091b92a3ead8c5b9358f9e6c65a13b8fbd7f183",
+                "reference": "d091b92a3ead8c5b9358f9e6c65a13b8fbd7f183",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
-                "php": "^8.0|^7.3"
+                "maml/maml": "^3.2",
+                "php": "^8.3",
+                "symfony/console": "^7.4.0 || ^8.0.0",
+                "symfony/process": "^7.4.0 || ^8.0.0",
+                "symfony/yaml": "^7.4.0 || ^8.0.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.64",
-                "pestphp/pest": "^3.3",
-                "phpstan/phpstan": "^1.4",
-                "phpunit/php-code-coverage": "^11.0",
-                "phpunit/phpunit": "^11.4"
+                "friendsofphp/php-cs-fixer": "^3.68",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/php-code-coverage": "^12.0",
+                "phpunit/phpunit": "^12.5"
             },
             "bin": [
                 "bin/dep"
             ],
             "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Support/helpers.php"
+                ],
+                "psr-4": {
+                    "Deployer\\": "src/"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -58,7 +69,937 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-19T16:45:27+00:00"
+            "time": "2026-04-26T21:29:38+00:00"
+        },
+        {
+            "name": "maml/maml",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maml-dev/maml-php.git",
+                "reference": "f11cdff4325bf399f23c33fc1995450e40ac0854"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maml-dev/maml-php/zipball/f11cdff4325bf399f23c33fc1995450e40ac0854",
+                "reference": "f11cdff4325bf399f23c33fc1995450e40ac0854",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "php-cs-fixer/shim": "^3.94",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Maml\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anton Medvedev",
+                    "email": "anton@medv.io"
+                }
+            ],
+            "description": "MAML Parser",
+            "homepage": "https://maml.dev",
+            "keywords": [
+                "config",
+                "configuration",
+                "maml",
+                "parser",
+                "serializer"
+            ],
+            "support": {
+                "issues": "https://github.com/maml-dev/maml-php/issues",
+                "source": "https://github.com/maml-dev/maml-php/tree/v3.2.0"
+            },
+            "time": "2026-04-12T16:50:36+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "reference": "85095d2573eaefaf35e40b9513a9bf09f72cd217",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^7.2|^8.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/lock": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-24T08:56:14+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-13T15:52:40+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T05:58:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:48:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:51:13+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-23T16:05:06+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-28T09:44:51+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.33",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-23T15:23:29+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "reference": "a7ec3b1156faf8815db7683ec7c1e7338e6f977c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T06:06:12+00:00"
         }
     ],
     "packages-dev": [
@@ -780,59 +1721,6 @@
                 }
             ],
             "time": "2026-01-27T05:48:37+00:00"
-        },
-        {
-            "name": "psr/container",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/container.git",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common Container Interface (PHP FIG PSR-11)",
-            "homepage": "https://github.com/php-fig/container",
-            "keywords": [
-                "PSR-11",
-                "container",
-                "container-interface",
-                "container-interop",
-                "psr"
-            ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.2"
-            },
-            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1867,747 +2755,6 @@
             "time": "2025-11-10T16:43:36+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v6.4.36",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "9f481cfb580db8bcecc9b2d4c63f3e13df022ad5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9f481cfb580db8bcecc9b2d4c63f3e13df022ad5",
-                "reference": "9f481cfb580db8bcecc9b2d4c63f3e13df022ad5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0|^7.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0|2.0|3.0"
-            },
-            "require-dev": {
-                "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Console\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Eases the creation of beautiful and testable command line interfaces",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "cli",
-                "command-line",
-                "console",
-                "terminal"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.36"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-03-27T15:30:51+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:21:43+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
-                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-ctype": "*"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's grapheme_* functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "grapheme",
-                "intl",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-26T13:13:48+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-09T11:45:10+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-mbstring": "*"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T17:25:58+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v6.4.33",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/c46e854e79b52d07666e43924a20cb6dc546644e",
-                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.33"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-01-23T16:02:12+00:00"
-        },
-        {
-            "name": "symfony/service-contracts",
-            "version": "v3.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/container": "^1.1|^2.0",
-                "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.6-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Service\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to writing services",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-07-15T11:30:57+00:00"
-        },
-        {
-            "name": "symfony/string",
-            "version": "v6.4.34",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/string.git",
-                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/2adaf4106f2ef4c67271971bde6d3fe0a6936432",
-                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
-            },
-            "conflict": {
-                "symfony/translation-contracts": "<2.5"
-            },
-            "require-dev": {
-                "symfony/http-client": "^5.4|^6.0|^7.0",
-                "symfony/intl": "^6.2|^7.0",
-                "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0|^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "grapheme",
-                "i18n",
-                "string",
-                "unicode",
-                "utf-8",
-                "utf8"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.34"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-02-08T20:44:54+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
             "version": "1.3.1",
             "source": {
@@ -2664,7 +2811,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.2",
+        "composer-runtime-api": "^2.0"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "deployer/deployer",
-            "version": "v8.0.0",
+            "version": "v8.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/deployphp/deployer.git",
-                "reference": "d091b92a3ead8c5b9358f9e6c65a13b8fbd7f183"
+                "reference": "199273500b4f14ff5eafd76bea524e5d44bcaff3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/deployphp/deployer/zipball/d091b92a3ead8c5b9358f9e6c65a13b8fbd7f183",
-                "reference": "d091b92a3ead8c5b9358f9e6c65a13b8fbd7f183",
+                "url": "https://api.github.com/repos/deployphp/deployer/zipball/199273500b4f14ff5eafd76bea524e5d44bcaff3",
+                "reference": "199273500b4f14ff5eafd76bea524e5d44bcaff3",
                 "shasum": ""
             },
             "require": {
@@ -69,7 +69,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-26T21:29:38+00:00"
+            "time": "2026-05-18T16:59:34+00:00"
         },
         {
             "name": "maml/maml",
@@ -1241,11 +1241,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.54",
+            "version": "2.2.1",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
-                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dea9c8f2d25cc849391042b71e429c1a4bf82660",
+                "reference": "dea9c8f2d25cc849391042b71e429c1a4bf82660",
                 "shasum": ""
             },
             "require": {
@@ -1267,6 +1267,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -1290,7 +1301,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-29T13:31:09+00:00"
+            "time": "2026-05-28T14:44:12+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,14 @@ parameters:
         - tasks
         - recipes
         - examples
+        - phpstan
     scanDirectories:
         - vendor/deployer/deployer
     bootstrapFiles:
         - stubs/deployer-v7.php
+
+services:
+    -
+        class: Gaambo\DeployerWordpress\PHPStan\DeployerVersionCompatExtension
+        tags:
+            - phpstan.ignoreErrorExtension

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,5 @@ parameters:
         - examples
     scanDirectories:
         - vendor/deployer/deployer
+    bootstrapFiles:
+        - stubs/deployer-v7.php

--- a/phpstan/DeployerVersionCompatExtension.php
+++ b/phpstan/DeployerVersionCompatExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaambo\DeployerWordpress\PHPStan;
+
+use Composer\InstalledVersions;
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Error;
+use PHPStan\Analyser\IgnoreErrorExtension;
+use PHPStan\Analyser\Scope;
+
+/**
+ * Suppresses v7/v8 compat errors on Deployer\runLocally calls.
+ *
+ * - argument.unknown: v8 named params are unknown in the v7 signature → suppress on v7
+ * - argument.type:    v7 array $options is incompatible with v8 ?string $cwd → suppress on v8
+ *
+ * Both are intentional and will be removed when v7 support is dropped.
+ */
+final class DeployerVersionCompatExtension implements IgnoreErrorExtension
+{
+    public function shouldIgnore(Error $error, Node $node, Scope $scope): bool
+    {
+        $identifier = $error->getIdentifier();
+
+        $isV8 = version_compare(
+            InstalledVersions::getVersion('deployer/deployer') ?? '0.0.0',
+            '8.0.0',
+            '>='
+        );
+
+        // argument.unknown only appears when analysing against v7
+        // argument.type only appears when analysing against v8
+        if ($identifier === 'argument.unknown' && $isV8) {
+            return false;
+        }
+        if ($identifier === 'argument.type' && !$isV8) {
+            return false;
+        }
+        if ($identifier !== 'argument.unknown' && $identifier !== 'argument.type') {
+            return false;
+        }
+
+        if (!$node instanceof FuncCall || !$node->name instanceof Name) {
+            return false;
+        }
+
+        $name = $node->name->toString();
+        return $name === 'runLocally' || $name === 'Deployer\\runLocally';
+    }
+}

--- a/recipes/common.php
+++ b/recipes/common.php
@@ -12,6 +12,7 @@ use Deployer\Exception\ConfigurationException;
 use Deployer\Host\Host;
 use Gaambo\DeployerWordpress\Composer;
 use Gaambo\DeployerWordpress\Localhost;
+use Gaambo\DeployerWordpress\Utils;
 use Gaambo\DeployerWordpress\WPCLI;
 
 use function Deployer\after;
@@ -27,7 +28,6 @@ use function Deployer\output;
 use function Deployer\run;
 use function Deployer\selectedHosts;
 use function Deployer\set;
-use function Deployer\Support\escape_shell_argument;
 use function Deployer\task;
 use function Deployer\test;
 use function Deployer\timestamp;
@@ -294,7 +294,7 @@ task('deploy:release', function () {
     ];
 
     // Save metainfo about release.
-    $json = escape_shell_argument(json_encode($metainfo));
+    $json = Utils::quote(json_encode($metainfo));
     run("echo $json >> .dep/releases_log");
 });
 

--- a/src/Localhost.php
+++ b/src/Localhost.php
@@ -5,6 +5,7 @@ namespace Gaambo\DeployerWordpress;
 use Deployer\Deployer;
 use Deployer\Host\Host;
 use Deployer\Task\Context;
+use Gaambo\DeployerWordpress\Utils;
 
 use function Deployer\on;
 use function Deployer\runLocally;
@@ -52,35 +53,34 @@ class Localhost
      *     timeout?:int|null,
      *     idleTimeout?:int|null,
      *     env?:array<string,string>|null,
-     *     secrets?:array<string,mixed>|null,
+     *     secrets?:array<string,string>|null,
      *     nothrow?:bool,
      *     forceOutput?:bool,
      *     shell?:string|null
-     * }|null $options
-     *   v8 named parameters (timeout, env, nothrow, forceOutput, shell).
-     *   Ignored on v7 since no callers pass options.
+     * }|null $options On v8 extracted to named parameters; on v7 passed as array.
      * @return string
      */
     public static function run(string $command, ?array $options = null): string
     {
         $result = null;
         on(self::get(), function () use ($command, $options, &$result) {
-            // Deployer v7/v8 compat: v8 uses named parameters; v7 used an options array.
-            // No callers pass $options, so v7 always falls through to runLocally($command).
-            if ($options !== null && Utils::isDeployerVersion('>=', '8.0.0')) {
+            $runOpts = $options ?? [];
+            if (Utils::isDeployerVersion('>=', '8.0.0')) {
+                // v8: runLocally uses named parameters (argument.unknown suppressed by DeployerVersionCompatExtension).
                 $result = runLocally(
                     $command,
-                    cwd: $options['cwd'] ?? null,
-                    timeout: $options['timeout'] ?? null,
-                    idleTimeout: $options['idleTimeout'] ?? null,
-                    secrets: $options['secrets'] ?? null,
-                    env: $options['env'] ?? null,
-                    forceOutput: $options['forceOutput'] ?? false,
-                    nothrow: $options['nothrow'] ?? false,
-                    shell: $options['shell'] ?? null,
+                    cwd: $runOpts['cwd'] ?? null,
+                    timeout: $runOpts['timeout'] ?? null,
+                    idleTimeout: $runOpts['idleTimeout'] ?? null,
+                    secrets: $runOpts['secrets'] ?? null,
+                    env: $runOpts['env'] ?? null,
+                    forceOutput: $runOpts['forceOutput'] ?? false,
+                    nothrow: $runOpts['nothrow'] ?? false,
+                    shell: $runOpts['shell'] ?? null,
                 );
             } else {
-                $result = runLocally($command);
+                // v7 compat: runLocally accepted an options array. Remove when v7 support is dropped.
+                $result = runLocally($command, $runOpts);
             }
         });
         return $result;

--- a/src/Localhost.php
+++ b/src/Localhost.php
@@ -47,14 +47,41 @@ class Localhost
      * does not use our Localhost instance.
      *
      * @param string $command Command to run on localhost.
-     * @param string[]|null $options Array of options will override passed named arguments.
+     * @param array{
+     *     cwd?:string|null,
+     *     timeout?:int|null,
+     *     idleTimeout?:int|null,
+     *     env?:array<string,string>|null,
+     *     secrets?:array<string,mixed>|null,
+     *     nothrow?:bool,
+     *     forceOutput?:bool,
+     *     shell?:string|null
+     * }|null $options
+     *   v8 named parameters (timeout, env, nothrow, forceOutput, shell).
+     *   Ignored on v7 since no callers pass options.
      * @return string
      */
-    public static function run(string $command, ?array $options = []): string
+    public static function run(string $command, ?array $options = null): string
     {
         $result = null;
         on(self::get(), function () use ($command, $options, &$result) {
-            $result = runLocally($command, $options);
+            // Deployer v7/v8 compat: v8 uses named parameters; v7 used an options array.
+            // No callers pass $options, so v7 always falls through to runLocally($command).
+            if ($options !== null && Utils::isDeployerVersion('>=', '8.0.0')) {
+                $result = runLocally(
+                    $command,
+                    cwd: $options['cwd'] ?? null,
+                    timeout: $options['timeout'] ?? null,
+                    idleTimeout: $options['idleTimeout'] ?? null,
+                    secrets: $options['secrets'] ?? null,
+                    env: $options['env'] ?? null,
+                    forceOutput: $options['forceOutput'] ?? false,
+                    nothrow: $options['nothrow'] ?? false,
+                    shell: $options['shell'] ?? null,
+                );
+            } else {
+                $result = runLocally($command);
+            }
         });
         return $result;
     }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -2,10 +2,40 @@
 
 namespace Gaambo\DeployerWordpress;
 
+use Composer\InstalledVersions;
+
 use function Deployer\output;
+use function Deployer\quote as deployerQuote; // Deployer v8
+use function Deployer\Support\escape_shell_argument;
+
+// Deployer v7
 
 class Utils
 {
+    /** @var array<string,bool> Cached results keyed by "$operator$version". */
+    private static array $versionCache = [];
+
+    /**
+     * Check the installed deployer/deployer version against a given constraint.
+     *
+     * Example: Utils::isDeployerVersion('>=', '8.0.0')
+     *
+     * @param string $operator A version_compare operator: '>=', '>', '==', '<', '<=', '!='
+     * @param string $version  Version string to compare against, e.g. '8.0.0'
+     */
+    public static function isDeployerVersion(string $operator, string $version): bool
+    {
+        $key = $operator . $version;
+        if (!array_key_exists($key, self::$versionCache)) {
+            self::$versionCache[$key] = version_compare(
+                InstalledVersions::getVersion('deployer/deployer') ?? '0.0.0',
+                $version,
+                $operator
+            );
+        }
+        return self::$versionCache[$key];
+    }
+
     /**
      * Get the verbosity argument based on Deployer's output verbosity
      *
@@ -54,5 +84,16 @@ class Utils
     public static function parseStringOrNull(mixed $string): ?string
     {
         return is_string($string) ? $string : null;
+    }
+
+    /**
+     * Deployer v7/v8 compat: v7 uses Deployer\Support\escape_shell_argument, v8 uses Deployer\quote.
+     */
+    public static function quote(string $arg): string
+    {
+        if (self::isDeployerVersion('>=', '8.0.0')) {
+            return deployerQuote($arg);
+        }
+        return escape_shell_argument($arg);
     }
 }

--- a/stubs/deployer-v7.php
+++ b/stubs/deployer-v7.php
@@ -7,11 +7,24 @@
  */
 
 namespace Deployer\Support {
+    if (!function_exists('Deployer\\Support\\escape_shell_argument')) {
+        function escape_shell_argument(string $argument): string
+        {
+            return "'" . str_replace("'", "'\\''", $argument) . "'";
+        }
+    }
+}
+
+namespace Deployer {
     /**
-     * Escape a shell argument (replaced by Deployer\quote in v8).
+     * Shell-quote a string (added in Deployer v8, not present in v7).
+     * Declared here so v7 analysis resolves the symbol.
+     * Guard against redeclaration when v8 is installed and already defines it.
      */
-    function escape_shell_argument(string $argument): string
-    {
-        return "'" . str_replace("'", "'\\''", $argument) . "'";
+    if (!function_exists('Deployer\\quote')) {
+        function quote(string $arg): string
+        {
+            return escapeshellarg($arg);
+        }
     }
 }

--- a/stubs/deployer-v7.php
+++ b/stubs/deployer-v7.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * PHPStan stubs for Deployer v7 symbols that were removed in v8.
+ * PHPStan runs against the installed version (v8), so v7-only functions are
+ * declared here so the v7 compatibility code paths still type-check.
+ */
+
+namespace Deployer\Support {
+    /**
+     * Escape a shell argument (replaced by Deployer\quote in v8).
+     */
+    function escape_shell_argument(string $argument): string
+    {
+        return "'" . str_replace("'", "'\\''", $argument) . "'";
+    }
+}

--- a/stubs/deployer-v7.php
+++ b/stubs/deployer-v7.php
@@ -1,9 +1,10 @@
 <?php
 
 /**
- * PHPStan stubs for Deployer v7 symbols that were removed in v8.
- * PHPStan runs against the installed version (v8), so v7-only functions are
- * declared here so the v7 compatibility code paths still type-check.
+ * PHPStan stubs for Deployer symbols that differ between v7 and v8.
+ *
+ * PHPStan analyses against the Deployer version installed in the current environment, so we
+ * declare functions that may be missing depending on whether v7 or v8 is installed.
  */
 
 namespace Deployer\Support {

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -10,6 +10,7 @@ use Deployer\Host\Host;
 use Deployer\Host\Localhost;
 use Deployer\Utility\Rsync;
 use Exception;
+use Gaambo\DeployerWordpress\Utils;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
@@ -160,8 +161,11 @@ abstract class FunctionalTestCase extends TestCase
             });
 
         // Use a closure factory, because the original runner needs dependencies.
+        // Deployer v7/v8 compat: constructor changed from ProcessRunner($pop, $logger) to ProcessRunner($logger).
         $this->deployer['processRunner'] = function ($c) {
-            $this->originalProcessRunner = new ProcessRunner($c['pop'], $c['logger']);
+            $this->originalProcessRunner = Utils::isDeployerVersion('>=', '8.0.0')
+                ? new ProcessRunner($c['logger'])             // v8
+                : new ProcessRunner($c['pop'], $c['logger']); // v7
             return $this->mockedRunner;
         };
     }

--- a/tests/Functional/Tasks/DatabaseTasksFunctionalTest.php
+++ b/tests/Functional/Tasks/DatabaseTasksFunctionalTest.php
@@ -191,7 +191,9 @@ class DatabaseTasksFunctionalTest extends FunctionalTestCase
         $result = $this->dep('db:remote:backup');
         $this->assertNotEquals(0, $result, 'Task should fail with invalid dump path');
         $output = $this->tester->getDisplay();
-        $this->assertStringContainsString('Task db:remote:backup failed', $output);
+        // Deployer v7/v8 compat: v7 says "Task db:remote:backup failed", v8 says "error in ...".
+        $this->assertStringContainsString('db:remote:backup', $output);
+        $this->assertMatchesRegularExpression('/failed|error/i', $output, 'Output should indicate failure (v7: "failed", v8: "error")');
 
         // Verify no dump files were created
         $remoteDumpFiles = glob($this->remoteDir . '/dumps/db_backup-*.sql');
@@ -343,7 +345,9 @@ class DatabaseTasksFunctionalTest extends FunctionalTestCase
         $result = $this->dep('db:local:backup');
         $this->assertNotEquals(0, $result, 'Task should fail with invalid dump path');
         $output = $this->tester->getDisplay();
-        $this->assertStringContainsString('Task db:local:backup failed', $output);
+        // Deployer v7/v8 compat: v7 says "Task db:local:backup failed", v8 says "error in ...".
+        $this->assertStringContainsString('db:local:backup', $output);
+        $this->assertMatchesRegularExpression('/failed|error/i', $output, 'Output should indicate failure (v7: "failed", v8: "error")');
 
         // Verify no dump files were created
         $localDumpFiles = glob($this->localDir . '/dumps/db_backup-*.sql');

--- a/tests/Integration/WpCliIntegrationTest.php
+++ b/tests/Integration/WpCliIntegrationTest.php
@@ -51,30 +51,30 @@ class WpCliIntegrationTest extends IntegrationTestCase
 
     public function testRunCommandLocally(): void
     {
-        // Note: We can't test for the host object because runLocally creates a new host instance
+        $expectedCommand = 'wp post list --format=table ';
+        // Note: We can't test for the host object because runLocally creates a new host instance.
         $this->processRunnerMock
             ->expects($this->once())
             ->method('run')
-            ->with(
-                $this->anything(), // Host object is not reliable as runLocally creates a new instance
-                'wp post list --format=table ',
-                []
-            );
+            ->willReturnCallback(function ($host, $command) use ($expectedCommand) {
+                $this->assertEquals($expectedCommand, $command);
+                return '';
+            });
 
         WPCLI::runCommandLocally('post list --format=table');
     }
 
     public function testRunCommandLocallyWithoutPath(): void
     {
-        // Note: We can't test for the host object because runLocally creates a new host instance
+        $expectedCommand = 'wp post list --format=table ';
+        // Note: We can't test for the host object because runLocally creates a new host instance.
         $this->processRunnerMock
             ->expects($this->once())
             ->method('run')
-            ->with(
-                $this->anything(), // Host object is not reliable as runLocally creates a new instance
-                'wp post list --format=table ',
-                []
-            );
+            ->willReturnCallback(function ($host, $command) use ($expectedCommand) {
+                $this->assertEquals($expectedCommand, $command);
+                return '';
+            });
 
         WPCLI::runCommandLocally('post list --format=table', false);
     }
@@ -227,11 +227,10 @@ class WpCliIntegrationTest extends IntegrationTestCase
         $this->processRunnerMock
             ->expects($this->once())
             ->method('run')
-            ->with(
-                $this->anything(),
-                $expectedCommand,
-                []
-            );
+            ->willReturnCallback(function ($host, $command) use ($expectedCommand) {
+                $this->assertEquals($expectedCommand, $command);
+                return '';
+            });
 
         WPCLI::runCommandLocally($command, $path, $arguments);
     }
@@ -270,11 +269,10 @@ class WpCliIntegrationTest extends IntegrationTestCase
         $this->processRunnerMock
             ->expects($this->once())
             ->method('run')
-            ->with(
-                $this->anything(),
-                $expectedCommand,
-                []
-            );
+            ->willReturnCallback(function ($host, $command) use ($expectedCommand) {
+                $this->assertEquals($expectedCommand, $command);
+                return '';
+            });
 
         WPCLI::runCommandLocally($command, $path, $arguments);
     }
@@ -311,11 +309,10 @@ class WpCliIntegrationTest extends IntegrationTestCase
         $this->processRunnerMock
             ->expects($this->once())
             ->method('run')
-            ->with(
-                $this->anything(),
-                $expectedCommand,
-                []
-            );
+            ->willReturnCallback(function ($host, $command) use ($expectedCommand) {
+                $this->assertEquals($expectedCommand, $command);
+                return '';
+            });
 
         WPCLI::runCommandLocally($command, $path, $arguments);
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,10 +6,26 @@ require __DIR__ . '/../vendor/autoload.php';
 // see https://github.com/deployphp/deployer/commit/76fadcd887eb22e37ffe92c5e05964ce43c9cfe5
 // And also add Deployer PSR-4 autoload-dev to composer.json
 // These are automatically loaded by Deployer when running the dep binary.
-require __DIR__ . '/../vendor/deployer/deployer/src/Support/helpers.php';
-require __DIR__ . '/../vendor/deployer/deployer/src/functions.php';
+// In deployer v8 these are added as autoload-files, therefore load conditionally.
+if(!function_exists('Deployer\Support\array_flatten')){
+    require __DIR__ . '/../vendor/deployer/deployer/src/Support/helpers.php';
+}
+if(!function_exists('Deployer\host')) {
+    require __DIR__ . '/../vendor/deployer/deployer/src/functions.php';
+}
 
 set_include_path(__DIR__ . '/../vendor/deployer/deployer' . PATH_SEPARATOR . get_include_path());
+
+// Deployer v7/v8 compat: alias moved/renamed classes under their v7 names so test files
+// can use a single import that works with both versions.
+// ProcessRunner: v7 Deployer\Component\ProcessRunner\ProcessRunner → v8 Deployer\ProcessRunner\ProcessRunner
+if (!class_exists('Deployer\Component\ProcessRunner\ProcessRunner') && class_exists('Deployer\ProcessRunner\ProcessRunner')) {
+    class_alias('Deployer\ProcessRunner\ProcessRunner', 'Deployer\Component\ProcessRunner\ProcessRunner');
+}
+// Ssh Client: v7 Deployer\Component\Ssh\Client → v8 Deployer\Ssh\SshClient (renamed + moved)
+if (!class_exists('Deployer\Component\Ssh\Client') && class_exists('Deployer\Ssh\SshClient')) {
+    class_alias('Deployer\Ssh\SshClient', 'Deployer\Component\Ssh\Client');
+}
 
 // Set up test environment
 putenv('DEPLOYER_LOCAL_WORKER=true');


### PR DESCRIPTION
## Add Deployer v8 support

#15

Extends compatibility from `deployer/deployer:^7.3` to also support `^8.0`, while keeping v7 working.

### What changed

**Runtime compatibility (`src/`)**
- `Utils::isDeployerVersion()` — new helper using `Composer\InstalledVersions` to check the installed Deployer version at runtime; used wherever behaviour differs between versions
- `Utils::quote()` — v7/v8 compat wrapper for shell-argument escaping (`Deployer\Support\escape_shell_argument` was replaced by `Deployer\quote` in v8)
- `Localhost::run()` — updated to use v8's named parameters for `runLocally()` (v8 replaced the options array with individual named params); v7 falls through to the no-options call since no callers pass options

**Recipes**
- `recipes/common.php` — replaces direct `escape_shell_argument` import with `Utils::quote()`

**Static analysis**
- `stubs/deployer-v7.php` — PHPStan bootstrap stub declaring v7-only symbols (`Deployer\Support\escape_shell_argument`) so v7 compatibility code paths type-check under v8; excluded from Composer dist via `.gitattributes`
- `phpstan.neon` — registers the stub via `bootstrapFiles`

**Test infrastructure**
- `tests/bootstrap.php` — guards the manual `require` of Deployer helper files (v8 autoloads them), and adds `class_alias` shims for moved classes (`ProcessRunner`, `Ssh\Client`) so test files use a single import for both versions
- `FunctionalTestCase.php` — `ProcessRunner` constructor changed in v8 from `($pop, $logger)` to `($logger)`; uses `Utils::isDeployerVersion` to select the right call
- `WpCliIntegrationTest.php` — migrated mock assertions from `->with($host, $command, $options)` to `->willReturnCallback(...)` because v8's `ProcessRunner::run()` dropped the third `$options` parameter
- `DatabaseTasksFunctionalTest.php` — replaced exact `"Task X failed"` string assertions with OR regex (`/failed|error/i`) to cover v7's and v8's different error output formats

**Dependencies**
- `composer.json`: constraint updated to `^7.3 || ^8.0`, `composer-runtime-api ^2.0` added to `require` (formalises the `InstalledVersions` dependency), Symfony dev deps widened to `^6.4 || ^7.4.0 || ^8.0.0`